### PR TITLE
增加官方分享功能

### DIFF
--- a/Login.xaml.cs
+++ b/Login.xaml.cs
@@ -74,7 +74,7 @@ namespace aliyundrive_Client_CSharp
             aliyundrive.token.SetToken(Txt_token.Text);
             if (aliyundrive.token.Instance.refresh_token == "")
             {
-                Txt_token.Text = "token格式错误,浏览器登录后,按F12打开控制台输入以下命令获取token:\r\nlocalStorage.getItem('token')";
+                Txt_token.Text = "token格式错误,浏览器登录后,按F12打开控制台输入以下命令获取refresh_token:\r\nJSON.parse(localStorage.getItem('token'));";
             }
             else
             {

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -137,6 +137,7 @@
                                 <ContextMenu StaysOpen="true">
                                     <MenuItem Header="二维码" Click="Button_Click_Server_QrShow"/>
                                     <MenuItem Header="分享FAP" Click="Button_Click_Server_Show"/>
+                                    <MenuItem Header="官方分享" Click="Button_Click_Server_Share"/>
                                     <MenuItem Header="搜索" Click="Button_Click_Server_Search"/>
                                     <MenuItem Header="复制下载链接" Click="Button_Click_Server_CopyDownUrl"/>
                                     <MenuItem Header="打开下载器" Click="Button_Click_Server_OpenDownUrl"/>
@@ -200,6 +201,7 @@
             IsReadOnly="True">
                             <DataGrid.ContextMenu>
                                 <ContextMenu StaysOpen="true">
+                                    <MenuItem Header="复制内容" Click="Button_Click_TaskCopyContent"/>
                                     <MenuItem Header="删除" Click="Button_Click_TaskDel"/>
                                 </ContextMenu>
                             </DataGrid.ContextMenu>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -363,25 +363,32 @@ namespace aliyundrive_Client_CSharp
 
             try
             {
-                string urls = "";
+                List<String> list = new List<string>();
+                string share_task_name = "";
                 if (serverFile.SelectedItems.Count == 1)
                 {
                     var item = ((info_file)serverFile.SelectedItems[0]);
-                    if (item.type == "folder") throw new Exception("暂时不支持复制目录,可以使用fap分享");
+                    //if (item.type == "folder") throw new Exception("暂时不支持分享目录,可以使用fap分享");
 
-                    Console.WriteLine($"Button_Click_Server_Del:{item.name},{item.file_id}");
-                    TaskMange.Add(new TaskInfo { Type = TaskType.分享, file_id = item.file_id, Name = item.name });
-                    Console.WriteLine($"copy:{urls}");
+                    Console.WriteLine($"Button_Click_Server_Share:{item.name},{item.file_id}");
+
+                    list.Add(item.file_id);
+                    share_task_name = item.name;
+                    
                 }
                 else
                 {
+
                     foreach (info_file item in serverFile.SelectedItems)
                     {
-                        Console.WriteLine($"copy:{item.name},{item.file_id},{item.download_url}");
-                        if (item.type == "folder") throw new Exception("暂时不支持复制目录,可以使用fap分享");
-                        urls += $"{item.name}:{item.download_url}\r\n";
+                        Console.WriteLine($"share:{item.name},{item.file_id}");
+                        // if (item.type == "folder") throw new Exception("暂时不支持分享目录,可以使用fap分享");
+                        list.Add(item.file_id);
+                        share_task_name = item.name;
                     }
+                    share_task_name += $" 等{serverFile.SelectedItems.Count}个文件 ";
                 }
+                TaskMange.Add(new TaskInfo { Type = TaskType.分享, file_id_list = list, Name = share_task_name}) ;
 
                 //if (urls == "") throw new Exception("没有url");
                 //Clipboard.SetText(urls);

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -358,6 +358,39 @@ namespace aliyundrive_Client_CSharp
                 MessageBox.Show(ex.Message);
             }
         }
+        private void Button_Click_Server_Share(object sender, RoutedEventArgs e)
+        {
+
+            try
+            {
+                string urls = "";
+                if (serverFile.SelectedItems.Count == 1)
+                {
+                    var item = ((info_file)serverFile.SelectedItems[0]);
+                    if (item.type == "folder") throw new Exception("暂时不支持复制目录,可以使用fap分享");
+
+                    Console.WriteLine($"Button_Click_Server_Del:{item.name},{item.file_id}");
+                    TaskMange.Add(new TaskInfo { Type = TaskType.分享, file_id = item.file_id, Name = item.name });
+                    Console.WriteLine($"copy:{urls}");
+                }
+                else
+                {
+                    foreach (info_file item in serverFile.SelectedItems)
+                    {
+                        Console.WriteLine($"copy:{item.name},{item.file_id},{item.download_url}");
+                        if (item.type == "folder") throw new Exception("暂时不支持复制目录,可以使用fap分享");
+                        urls += $"{item.name}:{item.download_url}\r\n";
+                    }
+                }
+
+                //if (urls == "") throw new Exception("没有url");
+                //Clipboard.SetText(urls);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+        }
         void ShowServerTip(string msg)
         {
             Dispatcher.Invoke(() =>
@@ -627,6 +660,16 @@ namespace aliyundrive_Client_CSharp
         private void task_MaxCount_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             TaskMange.MaxCount = (int)task_MaxCount.SelectedItem;
+        }
+        private void Button_Click_TaskCopyContent(object sender, RoutedEventArgs e)
+        {
+            List<TaskInfo> del = new List<TaskInfo>();
+            foreach (TaskInfo item in taskList.SelectedItems)
+            {
+                //复制任务名字
+                Clipboard.SetDataObject(item.Name);
+                //Clipboard.SetText(item.Name);
+            }
         }
         private void Button_Click_TaskDel(object sender, RoutedEventArgs e)
         {

--- a/TaskInfo.cs
+++ b/TaskInfo.cs
@@ -20,6 +20,7 @@ namespace aliyundrive_Client_CSharp
     {
         public string parent_file_id = "root";
         public string file_id = "";
+        public List<String> file_id_list;
         public string sha1 = "";
         public long size = 0;
         public string file_name = "";

--- a/TaskInfo.cs
+++ b/TaskInfo.cs
@@ -12,7 +12,7 @@ namespace aliyundrive_Client_CSharp
 
     public enum TaskType
     {
-        删除, 上传, 秒传, 目录, 改名,同步
+        删除, 上传, 秒传, 目录, 改名,同步, 分享
     }
 
 

--- a/TaskMange.cs
+++ b/TaskMange.cs
@@ -148,7 +148,7 @@ namespace aliyundrive_Client_CSharp
         {
             try
             {
-                var r = await new upload().share(task.file_id, task.Name, task);
+                var r = await new upload().share(task.file_id_list, task.Name, task);
                 if (r.success)
                 {
                     var content = JsonConvert.DeserializeObject<Dictionary<object, object>>(r.body);

--- a/TaskMange.cs
+++ b/TaskMange.cs
@@ -8,6 +8,9 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using System.Windows;
+using System.Threading;
 
 namespace aliyundrive_Client_CSharp
 {
@@ -61,6 +64,7 @@ namespace aliyundrive_Client_CSharp
                     case TaskType.删除: await Task_ServerDelFileAsync(task); break;
                     case TaskType.目录: await Task_Server_folder(task); break;
                     case TaskType.改名: await Task_Server_rename(task); break;
+                    case TaskType.分享: await Task_Server_share(task); break;
                 }
             });
         }
@@ -126,6 +130,34 @@ namespace aliyundrive_Client_CSharp
                 if (r.success)
                 {
                     OnServerFileChange(task.parent_file_id);
+                    task.Status = 2;
+                }
+                else
+                {
+                    task.Status = 3;
+                    task.Name = task.Name + $"[{r.Error}]";
+                }
+            }
+            catch (Exception ex)
+            {
+                task.Status = 3;
+                task.Name = task.Name + $"[{ex.Error()}]";
+            }
+        }
+        static async Task Task_Server_share(TaskInfo task)
+        {
+            try
+            {
+                var r = await new upload().share(task.file_id, task.Name, task);
+                if (r.success)
+                {
+                    var content = JsonConvert.DeserializeObject<Dictionary<object, object>>(r.body);
+                    var password = content["share_pwd"];
+                    var share_id = content["share_id"];
+                    var share_msg = content["share_msg"];
+                    var share_url = content["share_url"];
+                    // Clipboard.SetText($"{share_msg} {share_url}");
+                    task.Name = task.Name + $"{share_msg} {share_url}";
                     task.Status = 2;
                 }
                 else

--- a/aliyundrive/Util.cs
+++ b/aliyundrive/Util.cs
@@ -25,6 +25,7 @@ namespace aliyundrive_Client_CSharp.aliyundrive
         public static string file_create = api + "/file/create";
         public static string file_update = api + "/file/update";
         public static string file_get = api + "/file/get";
+        public static string file_share = api + "/share_link/create";
         public static string batch = api + "/batch";
         public static string databox_get_personal_info = api + "/databox/get_personal_info";
     }

--- a/aliyundrive/file.cs
+++ b/aliyundrive/file.cs
@@ -258,6 +258,24 @@ namespace aliyundrive_Client_CSharp.aliyundrive
             });
             return r;
         }
+        public async Task<HttpResult<upload>> share(string file_id, string name, TaskInfo task)
+        {
+            var f = this;
+            f.drive_id = token.Instance.default_drive_id;
+            f.file_id = file_id;
+            f.name = name;
+            var client = new Hclient<upload>();
+            List<String> list = new List<string>();
+            list.Add(file_id);
+            var r = await client.PostAsJsonAsync(DriveApi.file_share, new
+            {
+                drive_id = drive_id,
+                file_id_list = list,
+                share_pwd = Guid.NewGuid().ToString().Substring(0, 4),
+                expiration = "2030-04-15T17:13:58.720+08:00"
+            });
+            return r;
+        }
         public async Task<HttpResult<upload>> Upload(string file_id, string name,TaskInfo task)
         {
             var f = this;

--- a/aliyundrive/file.cs
+++ b/aliyundrive/file.cs
@@ -258,19 +258,18 @@ namespace aliyundrive_Client_CSharp.aliyundrive
             });
             return r;
         }
-        public async Task<HttpResult<upload>> share(string file_id, string name, TaskInfo task)
+        public async Task<HttpResult<upload>> share(List<String> file_id_list, string name, TaskInfo task)
         {
             var f = this;
             f.drive_id = token.Instance.default_drive_id;
             f.file_id = file_id;
             f.name = name;
             var client = new Hclient<upload>();
-            List<String> list = new List<string>();
-            list.Add(file_id);
+            
             var r = await client.PostAsJsonAsync(DriveApi.file_share, new
             {
                 drive_id = drive_id,
-                file_id_list = list,
+                file_id_list = file_id_list,
                 share_pwd = Guid.NewGuid().ToString().Substring(0, 4),
                 expiration = "2030-04-15T17:13:58.720+08:00"
             });

--- a/aliyundrive/token.cs
+++ b/aliyundrive/token.cs
@@ -31,6 +31,10 @@ namespace aliyundrive_Client_CSharp.aliyundrive
         {
             //"refresh_token":"72c8fa104efe4536816165dcebf1619c"
             var m=Regex.Match(str, "\"refresh_token\":\"(.+?)\"");
+            if (!m.Success)
+            {
+                m = Regex.Match(str, "refresh_token: \"(.+?)\"");
+            }
             Instance.refresh_token = m.Success ? m.Groups[1].Value : "";
         }
         public async Task<HttpResult<token>> Refresh()


### PR DESCRIPTION
增加官方分享功能，使用此功能需要先在APP端点击个人头像进行实名认证后才可以使用。

使用流程：在服务器文件区域，选中单个或者多个文件/文件夹，点击右键，选择“官方分享”，此时会创建一个分享任务。

如果执行成功，右侧的任务栏会看到分享结果，在任务栏中的分享任务上点击右键，点击“复制内容”，即可复制分享链接与分享提取码。